### PR TITLE
Modify react-select to work more like an autocomplete

### DIFF
--- a/examples/src/app.js
+++ b/examples/src/app.js
@@ -13,6 +13,7 @@ import CustomRender from './components/CustomRender';
 import Multiselect from './components/Multiselect';
 import NumericSelect from './components/NumericSelect';
 import BooleanSelect from './components/BooleanSelect';
+import ForkedSelect from './components/ForkedSelect';
 import Virtualized from './components/Virtualized';
 import States from './components/States';
 
@@ -31,6 +32,7 @@ ReactDOM.render(
 			hint="Enter a value that's NOT in the list, then hit return"
 			label="Custom tag creation"
 		/>
+		<ForkedSelect label="Forked Behavior" />
 	</div>,
 	document.getElementById('example')
 );

--- a/examples/src/components/ForkedSelect.js
+++ b/examples/src/components/ForkedSelect.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+
+/**
+ * This example demonstrates the enhancements and new properties available within this forked
+ * version of react-select. The specific properties are as follows:
+ *
+ * initInput - Input field is initialized with an initial value upon mount
+ * tabSelectsInput - Tabbing out will select the current value in the input field.
+ * enterSelectsInput - Hitting enter will select the current value in the input field.
+ * selectChangesInput - Helps to keep the input field in sync with the selected value.
+ * focusChangesInput - Helps to keep the input field in sync with the focused value.
+ *
+ */
+var ForkedSelect = createClass({
+	displayName: 'ForkedSelect',
+	propTypes: {
+		label: PropTypes.string
+	},
+	getInitialState () {
+		return {
+			options: [
+				{ value: 'Red', label: 'Red' },
+				{ value: 'Green', label: 'Green' },
+				{ value: 'Blue', label: 'Blue' }
+			],
+			value: undefined
+		};
+	},
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.value !== this.props.value) {
+			this.debug('QSN componentWillReceiveProps: selectedValue: '+nextProps.value);
+			this.lastFilter = nextProps.value;
+		}
+	},
+	handleOnChange (value) {
+		this.setState({ value });
+	},
+	debug(msg) {
+		// console.log(msg);
+	},
+	onSelect(value) {
+		this.debug(`onSelect: selectedValue: ${value} focus should be false`);
+		this.lastFilter = value;
+	},
+	filterOptions(options, filterValue, excludeOptions, props) {
+		this.debug(`filterOptions: options.length: ${options.length} filter: ${filterValue} first label: ${options.length > 0 ? options[0].label : ''}`);
+
+		//filter value should always be the input field value
+		if (!filterValue) {
+			this.debug('...returning no options');
+			return [];
+		}
+
+		let matchValue = filterValue;
+		if (this.lastFilter && this.lastFilter.length < filterValue.length) {
+			matchValue = this.lastFilter;
+		}
+		matchValue = matchValue.toLowerCase();
+
+		this.lastFilter = matchValue;
+
+		const result = options.filter((option) => {
+			return option[props.valueKey].toLowerCase().substr(0, matchValue.length) === matchValue;
+		});
+
+		this.debug(`filterOptions: matchValue: ${matchValue} found ${result.length} matches`);
+		return result;
+	},
+	isOptionUnique(ref) {
+		const { option, options, labelKey, valueKey } = ref;
+		if (!options || !options.length) {
+			return true;
+		}
+		const result = options.filter(function (existingOption) {
+				return existingOption[labelKey] === option[labelKey] || existingOption[valueKey] === option[valueKey];
+			}).length === 0;
+		this.debug(`isOptionUnique: value: ${option[valueKey]} label: ${option[labelKey]} result: ${result}`);
+		return result;
+	},
+	render () {
+		const { options, value } = this.state;
+		return (
+			<div className="section">
+				<h3 className="section-heading">{this.props.label} <a href="https://github.com/JedWatson/react-select/tree/master/examples/src/components/Creatable.js">(Source)</a></h3>
+				<Select.Creatable
+					initInput={true}
+					tabSelectsInput={true}
+					enterSelectsInput={true}
+					selectChangesInput={true}
+					focusChangesInput={true}
+					onSelectResetsInput={false}
+					onBlurResetsInput={false}
+					onCloseResetsInput={false}
+					multi={false}
+					options={options}
+					onChange={this.handleOnChange}
+					value={value}
+					filterOptions={this.filterOptions}
+					isOptionUnique={this.isOptionUnique}
+					onSelect={this.onSelect}
+					autosize={false}
+				/>
+			</div>
+		);
+	}
+});
+
+module.exports = ForkedSelect;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-select",
-  "version": "1.2.1",
+  "version": "1.2.1-A",
   "description": "A Select control built with and for ReactJS",
   "main": "lib/index.js",
   "jsnext:main": "dist/react-select.es.js",
@@ -86,7 +86,7 @@
     "deploy": "cross-env NODE_ENV=production nps publish",
     "start": "webpack-dev-server --progress",
     "test": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register",
-    "precommit": "lint-staged && yarn run test"
+    "precommit": "lint-staged && npm run test"
   },
   "files": ["dist", "less", "lib", "scss"],
   "keywords": [

--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -25,7 +25,12 @@ class CreatableSelect extends React.Component {
 		} = this.props;
 
 		if (isValidNewOption({ label: this.inputValue })) {
-			const option = newOptionCreator({ label: this.inputValue, labelKey: this.labelKey, valueKey: this.valueKey });
+			const option = newOptionCreator({
+				label: this.inputValue,
+				labelKey: this.labelKey,
+				valueKey: this.valueKey,
+				value: this.inputValue
+			});
 			const isOptionUnique = this.isOptionUnique({ option, options });
 
 			// Don't add the same option twice.
@@ -57,7 +62,8 @@ class CreatableSelect extends React.Component {
 			const option = newOptionCreator({
 				label: this.inputValue,
 				labelKey: this.labelKey,
-				valueKey: this.valueKey
+				valueKey: this.valueKey,
+				value: this.inputValue
 			});
 
 			// TRICKY Compare to all options (not just filtered options) in case option has already been selected).
@@ -73,10 +79,19 @@ class CreatableSelect extends React.Component {
 				this._createPlaceholderOption = newOptionCreator({
 					label: prompt,
 					labelKey: this.labelKey,
+					value: this.inputValue,
 					valueKey: this.valueKey
 				});
 
-				filteredOptions.unshift(this._createPlaceholderOption);
+				// Ensure we don't add the placeholder option twice:
+				const reallyUnique = this.isOptionUnique({
+					option: this._createPlaceholderOption,
+					options: excludeOptions.concat(filteredOptions)
+				});
+
+				if (reallyUnique) {
+					filteredOptions.unshift(this._createPlaceholderOption);
+				}
 			}
 		}
 
@@ -209,9 +224,9 @@ const isOptionUnique = ({ option, options, labelKey, valueKey }) => {
 
 const isValidNewOption = ({ label }) => !!label;
 
-const newOptionCreator = ({ label, labelKey, valueKey }) => {
+const newOptionCreator = ({ label, labelKey, valueKey, value }) => {
 	const option = {};
-	option[valueKey] = label;
+	option[valueKey] = value;
 	option[labelKey] = label;
 	option.className = 'Select-create-option-placeholder';
 

--- a/test/Creatable-test.js
+++ b/test/Creatable-test.js
@@ -270,14 +270,15 @@ describe('Creatable', () => {
 		expect(test(' '), 'to be', true);
 	});
 
-	it('default :newOptionCreator function should create an option with a :label and :value equal to the label string', () => {
+	it('default :newOptionCreator function should create an option with a :label equal to the label string', () => {
 		const option = Select.Creatable.newOptionCreator({
-			label: 'foo',
+			label: 'Foo',
 			labelKey: 'label',
+			value: 'foo',
 			valueKey: 'value'
 		});
 		expect(option.className, 'to equal', 'Select-create-option-placeholder');
-		expect(option.label, 'to equal', 'foo');
+		expect(option.label, 'to equal', 'Foo');
 		expect(option.value, 'to equal', 'foo');
 	});
 


### PR DESCRIPTION
Several properties were added to subtly make react-select
work more like an autocomplete. In summary:
- Hidden input field is kept in sync with the selected value.
- Cursoring through the options will update the input field
- Tab and enter key can select the input field value rather
  than the focused option
- For creatable options, the option value is no longer identical
  to its label. Specifically, the value omits any prompt text.
  This supports the cursoring aspect, allowing us to populate
  the input field with the options's value.